### PR TITLE
fix: 🔧 resolved conflicting stealth class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "llm-scraper"
+name = "IoT-KG"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
@@ -18,5 +18,6 @@ dependencies = [
     "playwright-stealth>=2.0.0",
     "python-arango>=8.2.2",
     "sentence-transformers>=5.1.1",
+    "tf-playwright-stealth>=1.2.0",
     "tqdm>=4.67.1",
 ]

--- a/src/scraper/scrape.py
+++ b/src/scraper/scrape.py
@@ -3,33 +3,34 @@ import asyncio
 from src.configs.amazon import AMAZON_SELECTOR
 from src.configs.walmart import WALMART_SELECTOR
 
-from playwright.async_api import async_playwright
-from playwright_stealth import Stealth
+from playwright.sync_api import sync_playwright
+from playwright_stealth import stealth_sync
 
-# URL = 'https://www.amazon.com/Amazon-vibrant-helpful-routines-Charcoal/dp/B09B8V1LZ3/ref=sr_1_1?crid=1FILQKC6UQ9B5&dib=eyJ2IjoiMSJ9.z0kBrN5J4yDwE3Z69yvpFvmwHHypkHHD1EEB0Tq7d-twKIMmrd6CdpzAKHt3QwCIqpCGWOtUGso25ArgjUeQiby0wRAtPziXyEv_Tf6qw3ScIhyK8WiI5tvRhkwcaZAYJpqeIDTu_m3cf2k1gyY2IF6h7Q-TpQpXqLkVlwxHcP1Ckn7GRQitYbsIXzmMdVt_vBDTTWAeeARk7Yo7VrzCI4_YLLlMbjp_5sTMWrY7dRA.M_EhWcOAkjfHtGyy6bJoS1n8Dh5KYN-aTbt1Uez3DW0&dib_tag=se&keywords=echo%2Bdot&qid=1759097324&sprefix=echo%2Bdo%2Cspecialty-aps%2C87&sr=8-1-catcorr&srs=17938598011&ufe=app_do%3Aamzn1.fos.74097168-0c10-4b8a-b96b-8388a1a12daf&th=1'
-URL = 'https://www.walmart.com/ip/HomePod-mini-Midnight/8103503224?classType=VARIANT&athbdg=L1600&from=/search'
+URL = 'https://www.amazon.com/Amazon-vibrant-helpful-routines-Charcoal/dp/B09B8V1LZ3/ref=sr_1_1?crid=1FILQKC6UQ9B5&dib=eyJ2IjoiMSJ9.z0kBrN5J4yDwE3Z69yvpFvmwHHypkHHD1EEB0Tq7d-twKIMmrd6CdpzAKHt3QwCIqpCGWOtUGso25ArgjUeQiby0wRAtPziXyEv_Tf6qw3ScIhyK8WiI5tvRhkwcaZAYJpqeIDTu_m3cf2k1gyY2IF6h7Q-TpQpXqLkVlwxHcP1Ckn7GRQitYbsIXzmMdVt_vBDTTWAeeARk7Yo7VrzCI4_YLLlMbjp_5sTMWrY7dRA.M_EhWcOAkjfHtGyy6bJoS1n8Dh5KYN-aTbt1Uez3DW0&dib_tag=se&keywords=echo%2Bdot&qid=1759097324&sprefix=echo%2Bdo%2Cspecialty-aps%2C87&sr=8-1-catcorr&srs=17938598011&ufe=app_do%3Aamzn1.fos.74097168-0c10-4b8a-b96b-8388a1a12daf&th=1'
+# URL = 'https://www.walmart.com/ip/HomePod-mini-Midnight/8103503224?classType=VARIANT&athbdg=L1600&from=/search'
 
-async def main(url: str) -> list | None:
-        async with Stealth().use_async(async_playwright()) as pw:
+def main(url: str) -> list | None:
+        with sync_playwright() as p:
             try:
 
                 result = []
 
-                browser = await pw.firefox.launch(headless=False)
-                page = await browser.new_page()
-                await page.goto(url, wait_until='domcontentloaded')
+                browser = p.firefox.launch(headless=False)
+                page =  browser.new_page()
+                stealth_sync(page)
+                page.goto(url, wait_until='domcontentloaded')
 
-                await page.wait_for_timeout(5000)
+                page.wait_for_timeout(5000)
 
-                for key, value in WALMART_SELECTOR.items():
-                     result.append(await page.locator(value).inner_text())
+                for key, value in AMAZON_SELECTOR.items():
+                     result.append(page.locator(value).inner_text())
 
                 return result
             except:
                 return None
             finally:
-                await browser.close()
+                browser.close()
 
 
 if __name__ == '__main__':
-    print(asyncio.run(main(URL)))
+    print(main(URL))

--- a/src/scraper/scrape_to_disk.py
+++ b/src/scraper/scrape_to_disk.py
@@ -12,15 +12,14 @@ Example Command:
 
 import os
 import json
-import asyncio
 import datetime
 import argparse
 
 from src.configs.amazon import AMAZON_SELECTOR
 from src.configs.walmart import WALMART_SELECTOR
 
-from playwright.async_api import async_playwright
-from playwright_stealth import Stealth
+from playwright.sync_api import sync_playwright
+from playwright_stealth import stealth_sync
 
 # TODO: Have this read from a file of urls
 URLS = [
@@ -33,34 +32,35 @@ CONFIGS = {
     "walmart": WALMART_SELECTOR
 }
 
-async def scrape_to_disk(urls: list[str], config: str):
-    async with Stealth().use_async(async_playwright()) as p:
+def scrape_to_disk(urls: list[str], config: str):
+    with sync_playwright() as p:
             browser = None
             try:
-                browser = await p.firefox.launch(headless=False)
-                output_dir = f"src/data/html_dumps/{config}"
+                browser =  p.firefox.launch(headless=False)
+                output_dir = f"data/html_dumps/{config}"
                 os.makedirs(output_dir, exist_ok=True)
 
                 for url in urls:
-                    page = await browser.new_page()
+                    page = browser.new_page()
+                    stealth_sync(page)
                     try:
-                        await page.goto(url, wait_until='domcontentloaded')
-                        await page.wait_for_timeout(5000)
+                        page.goto(url, wait_until='domcontentloaded')
+                        page.wait_for_timeout(5000)
 
                         print(f"Scraping {url} using {config} config")
 
                         result = {"url": url}
                         for key, value in CONFIGS[config].items():
-                            result[key] = await page.locator(value).inner_text()
+                            result[key] = page.locator(value).inner_text()
 
                         with open(f"{output_dir}/{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json", "w", encoding="utf-8") as f:
                             f.write(json.dumps(result, indent=2))
                     finally:
-                        await page.close()
+                        page.close()
             except Exception as e:
                 raise Exception("Error scraping to disk: ", e)
             finally:
-                await browser.close()
+                browser.close()
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Scrape e-commerce websites')
@@ -76,4 +76,4 @@ if __name__ == '__main__':
     elif args.walmart:
         config = "walmart"
     
-    asyncio.run(scrape_to_disk(URLS, config))
+    scrape_to_disk(URLS, config)

--- a/src/validators/search/search.py
+++ b/src/validators/search/search.py
@@ -3,7 +3,7 @@ import urllib.parse
 from typing import List
 from src.types.search_result import SearchResult
 from playwright.sync_api import sync_playwright, Page, Browser
-from playwright_stealth import Stealth
+from playwright_stealth import stealth_sync
 
 class SearchClient:
 
@@ -15,7 +15,7 @@ class SearchClient:
     
     def search_queries(self, queries: List[str]) -> List[SearchResult]:
         """Execute multiple search queries and return result counts."""
-        with Stealth().use_sync(sync_playwright()) as p:
+        with sync_playwright() as p:
             browser = p.chromium.launch(headless=self.headless)
             try:
                 return self._search_with_browser(browser, queries)
@@ -25,6 +25,7 @@ class SearchClient:
     def _search_with_browser(self, browser: Browser, queries: List[str]) -> List[SearchResult]:
         """Execute searches using an open browser."""
         page = browser.new_page()
+        stealth_sync(page)
         results = []
         
         for query in queries:

--- a/uv.lock
+++ b/uv.lock
@@ -775,6 +775,47 @@ wheels = [
 ]
 
 [[package]]
+name = "iot-kg"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "crawl4ai" },
+    { name = "ddgs" },
+    { name = "dotenv" },
+    { name = "langchain" },
+    { name = "langchain-community" },
+    { name = "langchain-huggingface" },
+    { name = "langchain-ollama" },
+    { name = "langgraph" },
+    { name = "ollama" },
+    { name = "playwright" },
+    { name = "playwright-stealth" },
+    { name = "python-arango" },
+    { name = "sentence-transformers" },
+    { name = "tf-playwright-stealth" },
+    { name = "tqdm" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "crawl4ai", specifier = ">=0.7.4" },
+    { name = "ddgs", specifier = ">=9.5.2" },
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "langchain", specifier = ">=0.3.27" },
+    { name = "langchain-community", specifier = ">=0.3.31" },
+    { name = "langchain-huggingface", specifier = ">=0.3.1" },
+    { name = "langchain-ollama", specifier = ">=0.3.10" },
+    { name = "langgraph", specifier = ">=0.6.10" },
+    { name = "ollama", specifier = ">=0.6.0" },
+    { name = "playwright", specifier = ">=1.55.0" },
+    { name = "playwright-stealth", specifier = ">=2.0.0" },
+    { name = "python-arango", specifier = ">=8.2.2" },
+    { name = "sentence-transformers", specifier = ">=5.1.1" },
+    { name = "tf-playwright-stealth", specifier = ">=1.2.0" },
+    { name = "tqdm", specifier = ">=4.67.1" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1082,45 +1123,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/94/6428360df5200921727dc65f4c6612892ed1fbe2b33ddd11dbe308c8c7d5/litellm-1.78.2.tar.gz", hash = "sha256:1b2f741f8d508393ba56ef6f4d4d3f2ab80c341c4d7ebb65b185471411d1a7ea", size = 10773934 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/79/e8c57380e8e62bad39924878c4e6d9bee43d595e870533a1fdda20e8b62f/litellm-1.78.2-py3-none-any.whl", hash = "sha256:aba1c396aacaf88e93b317774be991e3932a4f00a963bdeb109069e89edce163", size = 9774515 },
-]
-
-[[package]]
-name = "llm-scraper"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "crawl4ai" },
-    { name = "ddgs" },
-    { name = "dotenv" },
-    { name = "langchain" },
-    { name = "langchain-community" },
-    { name = "langchain-huggingface" },
-    { name = "langchain-ollama" },
-    { name = "langgraph" },
-    { name = "ollama" },
-    { name = "playwright" },
-    { name = "playwright-stealth" },
-    { name = "python-arango" },
-    { name = "sentence-transformers" },
-    { name = "tqdm" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "crawl4ai", specifier = ">=0.7.4" },
-    { name = "ddgs", specifier = ">=9.5.2" },
-    { name = "dotenv", specifier = ">=0.9.9" },
-    { name = "langchain", specifier = ">=0.3.27" },
-    { name = "langchain-community", specifier = ">=0.3.31" },
-    { name = "langchain-huggingface", specifier = ">=0.3.1" },
-    { name = "langchain-ollama", specifier = ">=0.3.10" },
-    { name = "langgraph", specifier = ">=0.6.10" },
-    { name = "ollama", specifier = ">=0.6.0" },
-    { name = "playwright", specifier = ">=1.55.0" },
-    { name = "playwright-stealth", specifier = ">=2.0.0" },
-    { name = "python-arango", specifier = ">=8.2.2" },
-    { name = "sentence-transformers", specifier = ">=5.1.1" },
-    { name = "tqdm", specifier = ">=4.67.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

Resolved conflicting playwright_stealth imports.

## Why is this change being made?

After integrating Crawl4AI, the project now includes hidden dependencies such as tf-playwright-stealth, which shares the same internal module name (playwright_stealth) as the original playwright-stealth package.

This overlap causes import conflicts:
- The TF version exposes functions (stealth_sync, stealth_async)
- The original version exposes a class (Stealth)

Because both use the same module name, importing one or the other can silently break our scraping modules.
This PR resolves the conflict by standardizing imports to match the TF fork used by Crawl4AI.